### PR TITLE
instruct php to allow larger file uploads

### DIFF
--- a/php/.user.ini
+++ b/php/.user.ini
@@ -1,0 +1,5 @@
+max_execution_time=1800
+post_max_size=1000M
+upload_max_filesize=1000M
+max_input_time=1800
+max_file_uploads=300


### PR DESCRIPTION
I found that I couldn't upload images > 2MB, even with the nginx changes. It looks like php was also limited to 2MB, so I increased the limit. This may also fix https://github.com/jparyani/Lychee/issues/7.
